### PR TITLE
Bump version to replace yanked gem

### DIFF
--- a/lib/sshkit/backends/version.rb
+++ b/lib/sshkit/backends/version.rb
@@ -1,7 +1,7 @@
 module SSHKit
   module Backends
     class NetsshGlobal
-      VERSION = '0.1.0'
+      VERSION = '0.1.1'
     end
   end
 end


### PR DESCRIPTION
💁  Sadly v0.1.0 [was yanked from RubyGems](https://rubygems.org/gems/sshkit-backends-netssh_global/versions/0.1.0). This change bumps the patch version so that we can republish the changes required for Ruby 2.4 compatibility.