### PR TITLE
Updates to ensure compatability with latest Capistrano

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /Gemfile.lock
 /.vagrant
+/.idea

--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,2 @@
-tap 'caskroom/cask'
-brew 'brew-cask'
-
 cask 'vagrant'
 cask 'virtualbox'

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ rake
 ```ruby
 require 'sshkit/backends/netssh_global'
 
+set :sshkit_backend, SSHKit::Backend::NetsshGlobal
+
 SSHKit::Backend::NetsshGlobal.configure do |config|
   config.owner        = 'bob'       # Which user to sudo as for every command
   config.directory    = '/home/bob' # Can be specified if it is important to default commands to run in a 

--- a/lib/sshkit/backends/netssh_global.rb
+++ b/lib/sshkit/backends/netssh_global.rb
@@ -8,7 +8,7 @@ module SSHKit
         attr_writer :ssh_commands
 
         def ssh_commands
-          @ssh_commands || [:ssh, :git, :'ssh-add', :bundle]
+          @ssh_commands ||= [:ssh, :git, :'ssh-add', :bundle]
         end
       end
 

--- a/lib/sshkit/backends/netssh_global.rb
+++ b/lib/sshkit/backends/netssh_global.rb
@@ -66,8 +66,7 @@ module SSHKit
         end
       end
 
-      def command(*args)
-        options = args.extract_options!
+      def command(args, options)
         options.merge!(
           in: pwd,
           env: @env,
@@ -77,7 +76,7 @@ module SSHKit
           ssh_commands: property(:ssh_commands),
           shell: property(:shell)
         )
-        SSHKit::CommandSudoSshForward.new(*[*args, options])
+        SSHKit::CommandSudoSshForward.new(*args.concat([options]))
       end
     end
   end

--- a/lib/sshkit/backends/netssh_global.rb
+++ b/lib/sshkit/backends/netssh_global.rb
@@ -50,16 +50,13 @@ module SSHKit
 
       def with_ssh
         configure_host
-        conn = self.class.pool.checkout(
-          String(host.hostname),
-          host.username,
-          host.netssh_options,
-          &Net::SSH.method(:start)
-        )
-        begin
-          yield conn.connection
-        ensure
-          self.class.pool.checkin conn
+        self.class.pool.with(
+            Net::SSH.method(:start),
+            String(host.hostname),
+            host.username,
+            host.netssh_options
+        ) do |connection|
+          yield connection
         end
       end
 

--- a/lib/sshkit/command_sudo_ssh_forward.rb
+++ b/lib/sshkit/command_sudo_ssh_forward.rb
@@ -1,3 +1,5 @@
+require 'sshkit'
+
 module SSHKit
   class CommandSudoSshForward < SSHKit::Command
     def to_command

--- a/lib/sshkit/command_sudo_ssh_forward.rb
+++ b/lib/sshkit/command_sudo_ssh_forward.rb
@@ -22,16 +22,6 @@ module SSHKit
       end
     end
 
-    def environment_string
-      environment_hash.collect do |key,value|
-        if key.is_a? Symbol
-          "#{key.to_s.upcase}=#{value}"
-        else
-          "#{key.to_s}=#{value}"
-        end
-      end.join(' ')
-    end
-
     def environment_hash
       default_env.merge(options_env)
     end

--- a/test/functional/backends/test_netssh_global.rb
+++ b/test/functional/backends/test_netssh_global.rb
@@ -33,17 +33,12 @@ module SSHKit
       end
 
       def test_capture
-        File.open('/dev/null', 'w') do |dnull|
-          SSHKit.capture_output(dnull) do
-            captured_command_result = nil
-            NetsshGlobal.new(a_host) do
-              captured_command_result = capture(:uname)
-            end.run
+        captured_command_result = nil
+        NetsshGlobal.new(a_host) do |_host|
+          captured_command_result = capture(:uname)
+        end.run
 
-            assert captured_command_result
-            assert_match captured_command_result, /Linux|Darwin/
-          end
-        end
+        assert_includes %W(Linux Darwin), captured_command_result
       end
 
       def test_ssh_option_merge

--- a/test/functional/backends/test_netssh_global.rb
+++ b/test/functional/backends/test_netssh_global.rb
@@ -150,14 +150,6 @@ module SSHKit
         assert(result, 'Expected test to execute as "owner", but it did not')
       end
 
-      def test_test_executes_as_ssh_user_when_command_contains_spaces
-        result = NetsshGlobal.new(a_host) do
-          test 'test "$USER" = "vagrant"'
-        end.run
-
-        assert(result, 'Expected test to execute as "vagrant", but it did not')
-      end
-
       def test_upload_file
         file_contents = ""
         file_owner = nil

--- a/test/functional/backends/test_netssh_global.rb
+++ b/test/functional/backends/test_netssh_global.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../../helper'
 require 'securerandom'
 
 require 'sshkit/backends/netssh_global'

--- a/test/functional/backends/test_netssh_global.rb
+++ b/test/functional/backends/test_netssh_global.rb
@@ -54,7 +54,10 @@ module SSHKit
           capture(:uname)
           host_ssh_options = host.ssh_options
         end.run
-        assert_equal({ forward_agent: false, paranoid: true }, host_ssh_options)
+        assert_equal [:forward_agent, :paranoid, :known_hosts, :logger, :password_prompt].sort, host_ssh_options.keys.sort
+        assert_equal false, host_ssh_options[:forward_agent]
+        assert_equal true, host_ssh_options[:paranoid]
+        assert_instance_of SSHKit::Backend::Netssh::KnownHosts, host_ssh_options[:known_hosts]
       end
 
       def test_configure_owner_via_global_config

--- a/test/functional/backends/test_netssh_global.rb
+++ b/test/functional/backends/test_netssh_global.rb
@@ -8,6 +8,10 @@ module SSHKit
     class TestNetsshGlobalFunctional < FunctionalTest
       def setup
         super
+        @output = String.new
+        SSHKit.config.output_verbosity = :debug
+        SSHKit.config.output = SSHKit::Formatter::SimpleText.new(@output)
+
         NetsshGlobal.configure do |config|
           config.owner = a_user
           config.directory = nil
@@ -32,6 +36,29 @@ module SSHKit
         VagrantWrapper.hosts['one']
       end
 
+      def test_simple_netssh
+        NetsshGlobal.new(a_host) do
+          execute 'date'
+          execute :ls, '-l'
+          with rails_env: :production do
+            within '/tmp' do
+              as :root do
+                execute :touch, 'restart.txt'
+              end
+            end
+          end
+        end.run
+
+        command_lines = @output.lines.select { |line| line.start_with?('Command:') }
+        assert_equal [
+                         "Command: sudo -u owner -- sh -c '/usr/bin/env date'\n",
+                         "Command: sudo -u owner -- sh -c '/usr/bin/env ls -l'\n",
+                         "Command: if test ! -d /tmp; then echo \"Directory does not exist '/tmp'\" 1>&2; false; fi\n",
+                         "Command: if ! sudo -u root whoami > /dev/null; then echo \"You cannot switch to user 'root' using sudo, please check the sudoers file\" 1>&2; false; fi\n",
+                         "Command: cd /tmp && sudo -u root RAILS_ENV=production -- sh -c '/usr/bin/env touch restart.txt'\n"
+                     ], command_lines
+      end
+
       def test_capture
         captured_command_result = nil
         NetsshGlobal.new(a_host) do |_host|
@@ -53,6 +80,16 @@ module SSHKit
         assert_equal false, host_ssh_options[:forward_agent]
         assert_equal true, host_ssh_options[:paranoid]
         assert_instance_of SSHKit::Backend::Netssh::KnownHosts, host_ssh_options[:known_hosts]
+      end
+
+      def test_env_vars_substituion_in_subshell
+        captured_command_result = nil
+        NetsshGlobal.new(a_host) do |_host|
+          with some_env_var: :some_value do
+            captured_command_result = capture(:echo, '$SOME_ENV_VAR')
+          end
+        end.run
+        assert_equal "some_value", captured_command_result
       end
 
       def test_configure_owner_via_global_config
@@ -215,6 +252,42 @@ module SSHKit
         assert_equal a_user, file_owner
       end
 
+      def test_upload_and_then_capture_file_contents
+        actual_file_contents = ""
+        actual_file_owner = nil
+        file_name = File.join("/tmp", SecureRandom.uuid)
+        File.open file_name, 'w+' do |f|
+          f.write "Some Content\nWith a newline and trailing spaces    \n "
+        end
+        NetsshGlobal.new(a_host) do
+          upload!(file_name, file_name)
+          actual_file_contents = capture(:cat, file_name, strip: false)
+          actual_file_owner = capture(:stat, '-c', '%U',  file_name)
+        end.run
+        assert_equal "Some Content\nWith a newline and trailing spaces    \n ", actual_file_contents
+        assert_equal a_user, actual_file_owner
+      end
+
+      def test_upload_within
+        file_name = SecureRandom.uuid
+        file_contents = "Some Content"
+        dir_name = SecureRandom.uuid
+        actual_file_contents = ""
+        actual_file_owner = nil
+        NetsshGlobal.new(a_host) do |_host|
+          within("/tmp") do
+            execute :mkdir, "-p", dir_name
+            within(dir_name) do
+              upload!(StringIO.new(file_contents), file_name)
+            end
+          end
+          actual_file_contents = capture(:cat, "/tmp/#{dir_name}/#{file_name}", strip: false)
+          actual_file_owner = capture(:stat, '-c', '%U', "/tmp/#{dir_name}/#{file_name}")
+        end.run
+        assert_equal file_contents, actual_file_contents
+        assert_equal a_user, actual_file_owner
+      end
+
       def test_upload_string_io
         file_contents = ""
         file_owner = nil
@@ -243,6 +316,31 @@ module SSHKit
         end.run
 
         assert_equal File.open(file_name).read, file_contents
+      end
+
+      def test_upload_via_pathname
+        file_contents = ""
+        file_owner = nil
+        NetsshGlobal.new(a_host) do |_host|
+          file_name = Pathname.new(File.join("/tmp", SecureRandom.uuid))
+          upload!(StringIO.new('example_io'), file_name)
+          file_owner = capture(:stat, '-c', '%U',  file_name)
+          file_contents = download!(file_name)
+        end.run
+        assert_equal "example_io", file_contents
+        assert_equal a_user, file_owner
+      end
+
+      def test_interaction_handler
+        captured_command_result = nil
+        NetsshGlobal.new(a_host) do
+          command = 'echo Enter Data; read the_data; echo Captured $the_data;'
+          captured_command_result = capture(command, interaction_handler: {
+              "Enter Data\n" => "SOME DATA\n",
+              "Captured SOME DATA\n" => nil
+          })
+        end.run
+        assert_equal("Enter Data\nCaptured SOME DATA", captured_command_result)
       end
 
       def test_ssh_forwarded_when_command_is_ssh_command

--- a/test/unit/backends/test_netssh_global.rb
+++ b/test/unit/backends/test_netssh_global.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../../helper'
 require 'sshkit/backends/netssh_global'
 
 module SSHKit

--- a/test/unit/test_command_sudo_ssh_forward.rb
+++ b/test/unit/test_command_sudo_ssh_forward.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'sshkit/command_sudo_ssh_forward'
 
 module SSHKit

--- a/test/unit/test_command_sudo_ssh_forward.rb
+++ b/test/unit/test_command_sudo_ssh_forward.rb
@@ -167,16 +167,49 @@ module SSHKit
       assert c.failed?
     end
 
-    def test_appending_stdout
+    def test_on_stdout
       c = CommandSudoSshForward.new(:whoami)
-      assert c.stdout += "test\n"
-      assert_equal "test\n", c.stdout
+      c.on_stdout(nil, "test\n")
+      c.on_stdout(nil, 'test2')
+      c.on_stdout(nil, 'test3')
+      assert_equal "test\ntest2test3", c.full_stdout
     end
 
-    def test_appending_stderr
+    def test_on_stderr
       c = CommandSudoSshForward.new(:whoami)
-      assert c.stderr += "test\n"
-      assert_equal "test\n", c.stderr
+      c.on_stderr(nil, 'test')
+      assert_equal 'test', c.full_stderr
+    end
+
+    def test_deprecated_stdtream_accessors
+      deprecation_out = ''
+      SSHKit.config.deprecation_output = deprecation_out
+
+      c = CommandSudoSshForward.new(:whoami)
+      c.stdout='a test'
+      assert_equal('a test', c.stdout)
+      c.stderr='another test'
+      assert_equal('another test', c.stderr)
+      deprecation_lines = deprecation_out.lines.to_a
+
+      assert_equal 8, deprecation_lines.size
+      assert_equal(
+          '[Deprecated] The stdout= method on Command is deprecated. ' +
+              "The @stdout attribute will be removed in a future release.\n",
+          deprecation_lines[0])
+      assert_equal(
+          '[Deprecated] The stdout method on Command is deprecated. ' +
+              "The @stdout attribute will be removed in a future release. Use full_stdout() instead.\n",
+          deprecation_lines[2])
+
+      assert_equal(
+          '[Deprecated] The stderr= method on Command is deprecated. ' +
+              "The @stderr attribute will be removed in a future release.\n",
+          deprecation_lines[4])
+      assert_equal(
+          '[Deprecated] The stderr method on Command is deprecated. ' +
+              "The @stderr attribute will be removed in a future release. Use full_stderr() instead.\n",
+          deprecation_lines[6])
     end
 
     def test_setting_exit_status

--- a/test/unit/test_command_sudo_ssh_forward.rb
+++ b/test/unit/test_command_sudo_ssh_forward.rb
@@ -19,7 +19,7 @@ module SSHKit
       end
     end
 
-    def test_using_a_heredoc
+    def test_multiple_lines_are_stripped_of_extra_space_and_joined_by_semicolons
       c = CommandSudoSshForward.new <<-EOHEREDOC
         if test ! -d /var/log; then
           echo "Example"
@@ -28,51 +28,68 @@ module SSHKit
       assert_equal "if test ! -d /var/log; then; echo \"Example\"; fi", c.to_command
     end
 
+    def test_leading_and_trailing_space_is_stripped
+      c = CommandSudoSshForward.new(" echo hi ")
+      assert_equal "echo hi", c.to_command
+    end
+
     def test_including_the_env
       SSHKit.config = nil
       c = CommandSudoSshForward.new(:rails, 'server', env: {rails_env: :production})
-      assert_equal "( RAILS_ENV=production /usr/bin/env rails server )", c.to_command
+      assert_equal '( RAILS_ENV="production" /usr/bin/env rails server )', c.to_command
     end
 
     def test_including_the_env_with_multiple_keys
       SSHKit.config = nil
       c = CommandSudoSshForward.new(:rails, 'server', env: {rails_env: :production, foo: 'bar'})
-      assert_equal "( RAILS_ENV=production FOO=bar /usr/bin/env rails server )", c.to_command
+      assert_equal '( RAILS_ENV="production" FOO="bar" /usr/bin/env rails server )', c.to_command
     end
 
     def test_including_the_env_with_string_keys
       SSHKit.config = nil
       c = CommandSudoSshForward.new(:rails, 'server', env: {'FACTER_env' => :production, foo: 'bar'})
-      assert_equal "( FACTER_env=production FOO=bar /usr/bin/env rails server )", c.to_command
+      assert_equal '( FACTER_env="production" FOO="bar" /usr/bin/env rails server )', c.to_command
+    end
+
+    def test_double_quotes_are_escaped_in_env
+      SSHKit.config = nil
+      c = CommandSudoSshForward.new(:rails, 'server', env: {foo: 'asdf"hjkl'})
+      assert_equal %{( FOO="asdf\\\"hjkl" /usr/bin/env rails server )}, c.to_command
+    end
+
+    def test_percentage_symbol_handled_in_env
+      SSHKit.config = nil
+      c = Command.new(:rails, 'server', env: {foo: 'asdf%hjkl'}, user: "anotheruser")
+      assert_equal %{( export FOO="asdf%hjkl" ; sudo -u anotheruser FOO=\"asdf%hjkl\" -- sh -c '/usr/bin/env rails server' )}, c.to_command
     end
 
     def test_including_the_env_doesnt_addressively_escape
       SSHKit.config = nil
       c = CommandSudoSshForward.new(:rails, 'server', env: {path: '/example:$PATH'})
-      assert_equal "( PATH=/example:$PATH /usr/bin/env rails server )", c.to_command
+      assert_equal '( PATH="/example:$PATH" /usr/bin/env rails server )', c.to_command
     end
 
     def test_global_env
       SSHKit.config = nil
       SSHKit.config.default_env = { default: 'env' }
       c = CommandSudoSshForward.new(:rails, 'server', env: {})
-      assert_equal "( DEFAULT=env /usr/bin/env rails server )", c.to_command
+      assert_equal '( DEFAULT="env" /usr/bin/env rails server )', c.to_command
     end
 
     def test_default_env_is_overwritten_with_locally_defined
       SSHKit.config.default_env = { foo: 'bar', over: 'under' }
       c = CommandSudoSshForward.new(:rails, 'server', env: { over: 'write'})
-      assert_equal "( FOO=bar OVER=write /usr/bin/env rails server )", c.to_command
+      assert_equal '( FOO="bar" OVER="write" /usr/bin/env rails server )', c.to_command
     end
 
     def test_working_in_a_given_directory
       c = CommandSudoSshForward.new(:ls, '-l', in: "/opt/sites")
-      assert_equal "cd /opt/sites && /usr/bin/env ls -l", c.to_command
+      assert_equal 'cd /opt/sites && /usr/bin/env ls -l', c.to_command
     end
 
     def test_working_in_a_given_directory_with_env
       c = CommandSudoSshForward.new(:ls, '-l', in: "/opt/sites", env: {a: :b})
-      assert_equal "cd /opt/sites && ( A=b /usr/bin/env ls -l )", c.to_command
+      assert_equal 'cd /opt/sites && ( A="b" /usr/bin/env ls -l )', c.to_command
     end
 
     def test_having_a_host_passed
@@ -122,7 +139,7 @@ module SSHKit
     def test_umask_with_env_and_working_directory_and_user
       SSHKit.config.umask = '007'
       c = CommandSudoSshForward.new(:touch, 'somefile', user: 'bob', env: {a: 'b'}, in: '/var')
-      assert_equal "cd /var && umask 007 && sudo -u bob A=b -- sh -c '/usr/bin/env touch somefile'", c.to_command
+      assert_equal 'cd /var && umask 007 && sudo -u bob A="b" -- sh -c \'/usr/bin/env touch somefile\'', c.to_command
     end
 
     def test_verbosity_defaults_to_logger_info
@@ -257,7 +274,7 @@ module SSHKit
       assert_equal(
         'setfacl -m fred:x $(dirname $SSH_AUTH_SOCK) && '\
         'setfacl -m fred:rw $SSH_AUTH_SOCK && '\
-        "sudo -u fred SSH_AUTH_SOCK=$SSH_AUTH_SOCK -- sh -c '/usr/bin/env whoami'", c.to_command
+        'sudo -u fred SSH_AUTH_SOCK="$SSH_AUTH_SOCK" -- sh -c \'/usr/bin/env whoami\'', c.to_command
       )
     end
 


### PR DESCRIPTION
There have been some API changes in Capistrano and SSHKit that have meant this backend is no longer compatible (e.g. https://github.com/capistrano/sshkit/commit/6de86147c015cea2c7f851a2e9e65fc91d47b9ee).

This pull request corrects that and makes it compatible with the latest version of Capistrano (3.10.1) once more.

Please see https://github.com/capistrano/sshkit/issues/262#issuecomment-361695958 for further background.