### PR TITLE
Ensure compatability with latest Capistrano

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /Gemfile.lock
 /.vagrant
+/.idea

--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,2 @@
-tap 'caskroom/cask'
-brew 'brew-cask'
-
 cask 'vagrant'
 cask 'virtualbox'

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ rake
 ```ruby
 require 'sshkit/backends/netssh_global'
 
+set :sshkit_backend, SSHKit::Backend::NetsshGlobal
+
 SSHKit::Backend::NetsshGlobal.configure do |config|
   config.owner        = 'bob'       # Which user to sudo as for every command
   config.directory    = '/home/bob' # Can be specified if it is important to default commands to run in a 

--- a/lib/sshkit/backends/version.rb
+++ b/lib/sshkit/backends/version.rb
@@ -1,7 +1,7 @@
 module SSHKit
   module Backends
     class NetsshGlobal
-      VERSION = '0.1.1'
+      VERSION = '0.2.0'
     end
   end
 end

--- a/lib/sshkit/command_sudo_ssh_forward.rb
+++ b/lib/sshkit/command_sudo_ssh_forward.rb
@@ -1,3 +1,5 @@
+require 'sshkit'
+
 module SSHKit
   class CommandSudoSshForward < SSHKit::Command
     def to_command
@@ -18,16 +20,6 @@ module SSHKit
           end
         end
       end
-    end
-
-    def environment_string
-      environment_hash.collect do |key,value|
-        if key.is_a? Symbol
-          "#{key.to_s.upcase}=#{value}"
-        else
-          "#{key.to_s}=#{value}"
-        end
-      end.join(' ')
     end
 
     def environment_hash

--- a/test/functional/backends/test_netssh_global.rb
+++ b/test/functional/backends/test_netssh_global.rb
@@ -55,7 +55,7 @@ module SSHKit
                          "Command: sudo -u owner -- sh -c '/usr/bin/env ls -l'\n",
                          "Command: if test ! -d /tmp; then echo \"Directory does not exist '/tmp'\" 1>&2; false; fi\n",
                          "Command: if ! sudo -u root whoami > /dev/null; then echo \"You cannot switch to user 'root' using sudo, please check the sudoers file\" 1>&2; false; fi\n",
-                         "Command: cd /tmp && sudo -u root RAILS_ENV=production -- sh -c '/usr/bin/env touch restart.txt'\n"
+                         "Command: cd /tmp && sudo -u root RAILS_ENV=\"production\" -- sh -c '/usr/bin/env touch restart.txt'\n"
                      ], command_lines
       end
 

--- a/test/functional/backends/test_netssh_global.rb
+++ b/test/functional/backends/test_netssh_global.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../../helper'
 require 'securerandom'
 
 require 'sshkit/backends/netssh_global'
@@ -8,6 +8,10 @@ module SSHKit
     class TestNetsshGlobalFunctional < FunctionalTest
       def setup
         super
+        @output = String.new
+        SSHKit.config.output_verbosity = :debug
+        SSHKit.config.output = SSHKit::Formatter::SimpleText.new(@output)
+
         NetsshGlobal.configure do |config|
           config.owner = a_user
           config.directory = nil
@@ -32,18 +36,36 @@ module SSHKit
         VagrantWrapper.hosts['one']
       end
 
-      def test_capture
-        File.open('/dev/null', 'w') do |dnull|
-          SSHKit.capture_output(dnull) do
-            captured_command_result = nil
-            NetsshGlobal.new(a_host) do
-              captured_command_result = capture(:uname)
-            end.run
-
-            assert captured_command_result
-            assert_match captured_command_result, /Linux|Darwin/
+      def test_simple_netssh
+        NetsshGlobal.new(a_host) do
+          execute 'date'
+          execute :ls, '-l'
+          with rails_env: :production do
+            within '/tmp' do
+              as :root do
+                execute :touch, 'restart.txt'
+              end
+            end
           end
-        end
+        end.run
+
+        command_lines = @output.lines.select { |line| line.start_with?('Command:') }
+        assert_equal [
+                         "Command: sudo -u owner -- sh -c '/usr/bin/env date'\n",
+                         "Command: sudo -u owner -- sh -c '/usr/bin/env ls -l'\n",
+                         "Command: if test ! -d /tmp; then echo \"Directory does not exist '/tmp'\" 1>&2; false; fi\n",
+                         "Command: if ! sudo -u root whoami > /dev/null; then echo \"You cannot switch to user 'root' using sudo, please check the sudoers file\" 1>&2; false; fi\n",
+                         "Command: cd /tmp && sudo -u root RAILS_ENV=production -- sh -c '/usr/bin/env touch restart.txt'\n"
+                     ], command_lines
+      end
+
+      def test_capture
+        captured_command_result = nil
+        NetsshGlobal.new(a_host) do |_host|
+          captured_command_result = capture(:uname)
+        end.run
+
+        assert_includes %W(Linux Darwin), captured_command_result
       end
 
       def test_ssh_option_merge
@@ -54,7 +76,20 @@ module SSHKit
           capture(:uname)
           host_ssh_options = host.ssh_options
         end.run
-        assert_equal({ forward_agent: false, paranoid: true }, host_ssh_options)
+        assert_equal [:forward_agent, :paranoid, :known_hosts, :logger, :password_prompt].sort, host_ssh_options.keys.sort
+        assert_equal false, host_ssh_options[:forward_agent]
+        assert_equal true, host_ssh_options[:paranoid]
+        assert_instance_of SSHKit::Backend::Netssh::KnownHosts, host_ssh_options[:known_hosts]
+      end
+
+      def test_env_vars_substituion_in_subshell
+        captured_command_result = nil
+        NetsshGlobal.new(a_host) do |_host|
+          with some_env_var: :some_value do
+            captured_command_result = capture(:echo, '$SOME_ENV_VAR')
+          end
+        end.run
+        assert_equal "some_value", captured_command_result
       end
 
       def test_configure_owner_via_global_config
@@ -152,14 +187,6 @@ module SSHKit
         assert(result, 'Expected test to execute as "owner", but it did not')
       end
 
-      def test_test_executes_as_ssh_user_when_command_contains_spaces
-        result = NetsshGlobal.new(a_host) do
-          test 'test "$USER" = "vagrant"'
-        end.run
-
-        assert(result, 'Expected test to execute as "vagrant", but it did not')
-      end
-
       def test_upload_file
         file_contents = ""
         file_owner = nil
@@ -225,6 +252,42 @@ module SSHKit
         assert_equal a_user, file_owner
       end
 
+      def test_upload_and_then_capture_file_contents
+        actual_file_contents = ""
+        actual_file_owner = nil
+        file_name = File.join("/tmp", SecureRandom.uuid)
+        File.open file_name, 'w+' do |f|
+          f.write "Some Content\nWith a newline and trailing spaces    \n "
+        end
+        NetsshGlobal.new(a_host) do
+          upload!(file_name, file_name)
+          actual_file_contents = capture(:cat, file_name, strip: false)
+          actual_file_owner = capture(:stat, '-c', '%U',  file_name)
+        end.run
+        assert_equal "Some Content\nWith a newline and trailing spaces    \n ", actual_file_contents
+        assert_equal a_user, actual_file_owner
+      end
+
+      def test_upload_within
+        file_name = SecureRandom.uuid
+        file_contents = "Some Content"
+        dir_name = SecureRandom.uuid
+        actual_file_contents = ""
+        actual_file_owner = nil
+        NetsshGlobal.new(a_host) do |_host|
+          within("/tmp") do
+            execute :mkdir, "-p", dir_name
+            within(dir_name) do
+              upload!(StringIO.new(file_contents), file_name)
+            end
+          end
+          actual_file_contents = capture(:cat, "/tmp/#{dir_name}/#{file_name}", strip: false)
+          actual_file_owner = capture(:stat, '-c', '%U', "/tmp/#{dir_name}/#{file_name}")
+        end.run
+        assert_equal file_contents, actual_file_contents
+        assert_equal a_user, actual_file_owner
+      end
+
       def test_upload_string_io
         file_contents = ""
         file_owner = nil
@@ -253,6 +316,31 @@ module SSHKit
         end.run
 
         assert_equal File.open(file_name).read, file_contents
+      end
+
+      def test_upload_via_pathname
+        file_contents = ""
+        file_owner = nil
+        NetsshGlobal.new(a_host) do |_host|
+          file_name = Pathname.new(File.join("/tmp", SecureRandom.uuid))
+          upload!(StringIO.new('example_io'), file_name)
+          file_owner = capture(:stat, '-c', '%U',  file_name)
+          file_contents = download!(file_name)
+        end.run
+        assert_equal "example_io", file_contents
+        assert_equal a_user, file_owner
+      end
+
+      def test_interaction_handler
+        captured_command_result = nil
+        NetsshGlobal.new(a_host) do
+          command = 'echo Enter Data; read the_data; echo Captured $the_data;'
+          captured_command_result = capture(command, interaction_handler: {
+              "Enter Data\n" => "SOME DATA\n",
+              "Captured SOME DATA\n" => nil
+          })
+        end.run
+        assert_equal("Enter Data\nCaptured SOME DATA", captured_command_result)
       end
 
       def test_ssh_forwarded_when_command_is_ssh_command

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -19,7 +19,7 @@ end
 class FunctionalTest < MiniTest::Unit::TestCase
   def setup
     unless VagrantWrapper.running?
-      warn "Vagrant VMs are not running. Please, start it manually with `vagrant up`"
+      skip "Vagrant VMs are not running. Please, start it manually with `vagrant up`"
     end
   end
 end

--- a/test/support/vagrant_wrapper.rb
+++ b/test/support/vagrant_wrapper.rb
@@ -31,10 +31,11 @@ class VagrantWrapper
     end
 
     def running?
-      @running ||= begin
-        status = `#{vagrant_binary} status`
-        status.include?('running')
-      end
+      return @running unless @running.nil?
+
+      status = `#{vagrant_binary} status`
+
+      @running = status.include?('running')
     end
 
     def boxes_list

--- a/test/support/vagrant_wrapper.rb
+++ b/test/support/vagrant_wrapper.rb
@@ -33,7 +33,7 @@ class VagrantWrapper
     def running?
       return @running unless @running.nil?
 
-      status = `#{vagrant_binary} status`
+      status = `#{vagrant_binary} status || true`
 
       @running = status.include?('running')
     end

--- a/test/unit/backends/test_netssh_global.rb
+++ b/test/unit/backends/test_netssh_global.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../../helper'
 require 'sshkit/backends/netssh_global'
 
 module SSHKit

--- a/test/unit/test_command_sudo_ssh_forward.rb
+++ b/test/unit/test_command_sudo_ssh_forward.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative '../helper'
 require 'sshkit/command_sudo_ssh_forward'
 
 module SSHKit
@@ -19,7 +19,7 @@ module SSHKit
       end
     end
 
-    def test_using_a_heredoc
+    def test_multiple_lines_are_stripped_of_extra_space_and_joined_by_semicolons
       c = CommandSudoSshForward.new <<-EOHEREDOC
         if test ! -d /var/log; then
           echo "Example"
@@ -28,51 +28,68 @@ module SSHKit
       assert_equal "if test ! -d /var/log; then; echo \"Example\"; fi", c.to_command
     end
 
+    def test_leading_and_trailing_space_is_stripped
+      c = CommandSudoSshForward.new(" echo hi ")
+      assert_equal "echo hi", c.to_command
+    end
+
     def test_including_the_env
       SSHKit.config = nil
       c = CommandSudoSshForward.new(:rails, 'server', env: {rails_env: :production})
-      assert_equal "( RAILS_ENV=production /usr/bin/env rails server )", c.to_command
+      assert_equal '( RAILS_ENV="production" /usr/bin/env rails server )', c.to_command
     end
 
     def test_including_the_env_with_multiple_keys
       SSHKit.config = nil
       c = CommandSudoSshForward.new(:rails, 'server', env: {rails_env: :production, foo: 'bar'})
-      assert_equal "( RAILS_ENV=production FOO=bar /usr/bin/env rails server )", c.to_command
+      assert_equal '( RAILS_ENV="production" FOO="bar" /usr/bin/env rails server )', c.to_command
     end
 
     def test_including_the_env_with_string_keys
       SSHKit.config = nil
       c = CommandSudoSshForward.new(:rails, 'server', env: {'FACTER_env' => :production, foo: 'bar'})
-      assert_equal "( FACTER_env=production FOO=bar /usr/bin/env rails server )", c.to_command
+      assert_equal '( FACTER_env="production" FOO="bar" /usr/bin/env rails server )', c.to_command
+    end
+
+    def test_double_quotes_are_escaped_in_env
+      SSHKit.config = nil
+      c = CommandSudoSshForward.new(:rails, 'server', env: {foo: 'asdf"hjkl'})
+      assert_equal %{( FOO="asdf\\\"hjkl" /usr/bin/env rails server )}, c.to_command
+    end
+
+    def test_percentage_symbol_handled_in_env
+      SSHKit.config = nil
+      c = Command.new(:rails, 'server', env: {foo: 'asdf%hjkl'}, user: "anotheruser")
+      assert_equal %{( export FOO="asdf%hjkl" ; sudo -u anotheruser FOO=\"asdf%hjkl\" -- sh -c '/usr/bin/env rails server' )}, c.to_command
     end
 
     def test_including_the_env_doesnt_addressively_escape
       SSHKit.config = nil
       c = CommandSudoSshForward.new(:rails, 'server', env: {path: '/example:$PATH'})
-      assert_equal "( PATH=/example:$PATH /usr/bin/env rails server )", c.to_command
+      assert_equal '( PATH="/example:$PATH" /usr/bin/env rails server )', c.to_command
     end
 
     def test_global_env
       SSHKit.config = nil
       SSHKit.config.default_env = { default: 'env' }
       c = CommandSudoSshForward.new(:rails, 'server', env: {})
-      assert_equal "( DEFAULT=env /usr/bin/env rails server )", c.to_command
+      assert_equal '( DEFAULT="env" /usr/bin/env rails server )', c.to_command
     end
 
     def test_default_env_is_overwritten_with_locally_defined
       SSHKit.config.default_env = { foo: 'bar', over: 'under' }
       c = CommandSudoSshForward.new(:rails, 'server', env: { over: 'write'})
-      assert_equal "( FOO=bar OVER=write /usr/bin/env rails server )", c.to_command
+      assert_equal '( FOO="bar" OVER="write" /usr/bin/env rails server )', c.to_command
     end
 
     def test_working_in_a_given_directory
       c = CommandSudoSshForward.new(:ls, '-l', in: "/opt/sites")
-      assert_equal "cd /opt/sites && /usr/bin/env ls -l", c.to_command
+      assert_equal 'cd /opt/sites && /usr/bin/env ls -l', c.to_command
     end
 
     def test_working_in_a_given_directory_with_env
       c = CommandSudoSshForward.new(:ls, '-l', in: "/opt/sites", env: {a: :b})
-      assert_equal "cd /opt/sites && ( A=b /usr/bin/env ls -l )", c.to_command
+      assert_equal 'cd /opt/sites && ( A="b" /usr/bin/env ls -l )', c.to_command
     end
 
     def test_having_a_host_passed
@@ -122,7 +139,7 @@ module SSHKit
     def test_umask_with_env_and_working_directory_and_user
       SSHKit.config.umask = '007'
       c = CommandSudoSshForward.new(:touch, 'somefile', user: 'bob', env: {a: 'b'}, in: '/var')
-      assert_equal "cd /var && umask 007 && sudo -u bob A=b -- sh -c '/usr/bin/env touch somefile'", c.to_command
+      assert_equal 'cd /var && umask 007 && sudo -u bob A="b" -- sh -c \'/usr/bin/env touch somefile\'', c.to_command
     end
 
     def test_verbosity_defaults_to_logger_info
@@ -167,16 +184,49 @@ module SSHKit
       assert c.failed?
     end
 
-    def test_appending_stdout
+    def test_on_stdout
       c = CommandSudoSshForward.new(:whoami)
-      assert c.stdout += "test\n"
-      assert_equal "test\n", c.stdout
+      c.on_stdout(nil, "test\n")
+      c.on_stdout(nil, 'test2')
+      c.on_stdout(nil, 'test3')
+      assert_equal "test\ntest2test3", c.full_stdout
     end
 
-    def test_appending_stderr
+    def test_on_stderr
       c = CommandSudoSshForward.new(:whoami)
-      assert c.stderr += "test\n"
-      assert_equal "test\n", c.stderr
+      c.on_stderr(nil, 'test')
+      assert_equal 'test', c.full_stderr
+    end
+
+    def test_deprecated_stdtream_accessors
+      deprecation_out = ''
+      SSHKit.config.deprecation_output = deprecation_out
+
+      c = CommandSudoSshForward.new(:whoami)
+      c.stdout='a test'
+      assert_equal('a test', c.stdout)
+      c.stderr='another test'
+      assert_equal('another test', c.stderr)
+      deprecation_lines = deprecation_out.lines.to_a
+
+      assert_equal 8, deprecation_lines.size
+      assert_equal(
+          '[Deprecated] The stdout= method on Command is deprecated. ' +
+              "The @stdout attribute will be removed in a future release.\n",
+          deprecation_lines[0])
+      assert_equal(
+          '[Deprecated] The stdout method on Command is deprecated. ' +
+              "The @stdout attribute will be removed in a future release. Use full_stdout() instead.\n",
+          deprecation_lines[2])
+
+      assert_equal(
+          '[Deprecated] The stderr= method on Command is deprecated. ' +
+              "The @stderr attribute will be removed in a future release.\n",
+          deprecation_lines[4])
+      assert_equal(
+          '[Deprecated] The stderr method on Command is deprecated. ' +
+              "The @stderr attribute will be removed in a future release. Use full_stderr() instead.\n",
+          deprecation_lines[6])
     end
 
     def test_setting_exit_status
@@ -224,7 +274,7 @@ module SSHKit
       assert_equal(
         'setfacl -m fred:x $(dirname $SSH_AUTH_SOCK) && '\
         'setfacl -m fred:rw $SSH_AUTH_SOCK && '\
-        "sudo -u fred SSH_AUTH_SOCK=$SSH_AUTH_SOCK -- sh -c '/usr/bin/env whoami'", c.to_command
+        'sudo -u fred SSH_AUTH_SOCK="$SSH_AUTH_SOCK" -- sh -c \'/usr/bin/env whoami\'', c.to_command
       )
     end
 

--- a/test/unit/test_command_sudo_ssh_forward.rb
+++ b/test/unit/test_command_sudo_ssh_forward.rb
@@ -110,12 +110,12 @@ module SSHKit
 
     def test_working_as_a_given_group
       c = CommandSudoSshForward.new(:whoami, group: :devvers)
-      assert_equal "sg devvers -c \\\"/usr/bin/env whoami\\\"", c.to_command
+      assert_equal %q[sg devvers -c "/usr/bin/env whoami"], c.to_command
     end
 
     def test_working_as_a_given_user_and_group
       c = CommandSudoSshForward.new(:whoami, user: :anotheruser, group: :devvers)
-      assert_equal "sudo -u anotheruser -- sh -c 'sg devvers -c \\\"/usr/bin/env whoami\\\"'", c.to_command
+      assert_equal %q[sudo -u anotheruser -- sh -c 'sg devvers -c "/usr/bin/env whoami"'], c.to_command
     end
 
     def test_umask


### PR DESCRIPTION
Follow up of https://github.com/FundingCircle/sshkit-backends-netssh_global/pull/8

There have been some API changes in Capistrano and SSHKit that have meant this backend is no longer compatible (e.g. capistrano/sshkit@6de8614).

This pull request corrects that and makes it compatible with the latest version of Capistrano (3.10.1) once more.

Please see capistrano/sshkit#262 (comment) for further background.

---

The unit specs now run in circleci, the functional should be ran locally with vagrant.