### PR TITLE
CircleCI and automating gem releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,13 @@
 version: 2
 
+rubygems-login: &rubygems-login
+  run:
+    name: Login to RubyGems
+    command: |
+      mkdir ~/.gem
+      echo ":rubygems_api_key: $RUBYGEMS_API_KEY" >  ~/.gem/credentials
+      chmod 0600 ~/.gem/credentials
+
 defaults: &defaults
   steps:
     - run: apk add --no-cache --no-progress git
@@ -8,7 +16,41 @@ defaults: &defaults
     - run: bundle exec rake test
   working_directory: ~/sshkit-backends-netssh_global
 
+default-deploys: &default-deploys
+  docker:
+    - image: ruby:alpine
+  working_directory: ~/sshkit-backends-netssh_global
+
 jobs:
+  deploy-gem:
+    <<: *default-deploys
+    steps:
+      - checkout
+      - *rubygems-login
+      - run:
+          name: Build gem
+          command: gem build "$CIRCLE_PROJECT_REPONAME".gemspec
+      - run:
+          name: Publish gem to RubyGems
+          command: |
+            package=$(ls -t1 "$CIRCLE_PROJECT_REPONAME"*.gem | head -1)
+            gem push "$CIRCLE_PROJECT_REPONAME"-"$(echo $CIRCLE_TAG | sed -e 's/v//')".gem
+  deploy-pre-release-gem:
+    <<: *default-deploys
+    steps:
+      - checkout
+      - *rubygems-login
+      - run:
+          name: Install gem-versioner
+          command: gem install gem-versioner
+      - run:
+          name: Build gem
+          command: PRE_RELEASE="$CIRCLE_BRANCH" gem build "$CIRCLE_PROJECT_REPONAME".gemspec
+      - run:
+          name: Push pre-release gem to RubyGems
+          command: |
+            package=$(ls -t1 "$CIRCLE_PROJECT_REPONAME"*.gem | head -1)
+            gem push "$package"
   test-ruby-2.2:
     <<: *defaults
     docker:
@@ -28,9 +70,43 @@ jobs:
 
 workflows:
   version: 2
-  test-against-rubies:
+  test-then-release-gem:
     jobs:
-      - test-ruby-2.2
-      - test-ruby-2.3
-      - test-ruby-2.4
-      - test-ruby-2.5
+      - test-ruby-2.2:
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d\+/
+      - test-ruby-2.3:
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d\+/
+      - test-ruby-2.4:
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d\+/
+      - test-ruby-2.5:
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d\+/
+      - deploy-gem:
+          context: org-global
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d\+/
+          requires:
+            - test-ruby-2.2
+            - test-ruby-2.3
+            - test-ruby-2.4
+            - test-ruby-2.5
+      - deploy-pre-release-gem:
+          context: org-global
+          filters:
+            branches:
+              ignore: master
+          requires:
+            - test-ruby-2.2
+            - test-ruby-2.3
+            - test-ruby-2.4
+            - test-ruby-2.5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,12 @@ rubygems-login: &rubygems-login
       echo ":rubygems_api_key: $RUBYGEMS_API_KEY" >  ~/.gem/credentials
       chmod 0600 ~/.gem/credentials
 
+install-git: &install-git
+  run: apk add --no-cache --no-progress git
+
 defaults: &defaults
   steps:
-    - run: apk add --no-cache --no-progress git
+    - *install-git
     - checkout
     - run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
     - run: bundle exec rake test
@@ -25,6 +28,7 @@ jobs:
   deploy-gem:
     <<: *default-deploys
     steps:
+      - *install-git
       - checkout
       - *rubygems-login
       - run:
@@ -38,6 +42,7 @@ jobs:
   deploy-pre-release-gem:
     <<: *default-deploys
     steps:
+      - *install-git
       - checkout
       - *rubygems-login
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+version: 2
+
+defaults: &defaults
+  steps:
+    - run: apk add --no-cache --no-progress git
+    - checkout
+    - run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
+    - run: bundle exec rake test
+  working_directory: ~/sshkit-backends-netssh_global
+
+jobs:
+  test-ruby-2.2:
+    <<: *defaults
+    docker:
+      - image: ruby:2.2-alpine
+  test-ruby-2.3:
+    <<: *defaults
+    docker:
+      - image: ruby:2.3-alpine
+  test-ruby-2.4:
+    <<: *defaults
+    docker:
+      - image: ruby:2.4-alpine
+  test-ruby-2.5:
+    <<: *defaults
+    docker:
+      - image: ruby:2.5-alpine
+
+workflows:
+  version: 2
+  test-against-rubies:
+    jobs:
+      - test-ruby-2.2
+      - test-ruby-2.3
+      - test-ruby-2.4
+      - test-ruby-2.5

--- a/lib/sshkit/backends/version.rb
+++ b/lib/sshkit/backends/version.rb
@@ -1,7 +1,0 @@
-module SSHKit
-  module Backends
-    class NetsshGlobal
-      VERSION = '0.2.0'
-    end
-  end
-end

--- a/sshkit-backends-netssh_global.gemspec
+++ b/sshkit-backends-netssh_global.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{A backend to be used in conjunction with Capistrano 3
 and SSHKit to allow deployment on setups where users login as one identity and
 then need to sudo to a different identity for each command.}
-  gem.homepage      = "http://github.com/FundingCircle/sshkit-backends-netssh_global"
+  gem.homepage      = "https://github.com/FundingCircle/sshkit-backends-netssh_global"
   gem.license       = "BSD-3-Clause"
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }

--- a/sshkit-backends-netssh_global.gemspec
+++ b/sshkit-backends-netssh_global.gemspec
@@ -1,6 +1,4 @@
 # -*- encoding: utf-8 -*-
-require File.expand_path('../lib/sshkit/backends/version', __FILE__)
-
 Gem::Specification.new do |gem|
 
   gem.authors       = ["Theo Cushion", "Dennis Ideler"]
@@ -17,7 +15,7 @@ then need to sudo to a different identity for each command.}
   gem.test_files    = `git ls-files -- test/*`.split("\n")
   gem.name          = "sshkit-backends-netssh_global"
   gem.require_paths = ["lib"]
-  gem.version       = SSHKit::Backends::NetsshGlobal::VERSION
+  gem.version       = '0.2.1'
 
   gem.add_runtime_dependency('sshkit', '~> 1.11')
 


### PR DESCRIPTION
💁 These changes add a CircleCI build configuration to run the test suite against multiple Ruby versions and push pre-release versions to RubyGems. Gem versions are only released to RubyGems when a new git tag is pushed.