### PR TITLE
Fix version regex

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,26 +80,26 @@ workflows:
       - test-ruby-2.2:
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d\+/
+              only: /^v\d+\.\d+\.\d+$/
       - test-ruby-2.3:
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d\+/
+              only: /^v\d+\.\d+\.\d+$/
       - test-ruby-2.4:
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d\+/
+              only: /^v\d+\.\d+\.\d+$/
       - test-ruby-2.5:
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d\+/
+              only: /^v\d+\.\d+\.\d+$/
       - deploy-gem:
           context: org-global
           filters:
             branches:
               ignore: /.*/
             tags:
-              only: /^v\d+\.\d+\.\d\+/
+              only: /^v\d+\.\d+\.\d+$/
           requires:
             - test-ruby-2.2
             - test-ruby-2.3


### PR DESCRIPTION
💁 The previous regular expression escaped a plus sign. This change resolves this.
```shell
irb(main):001:0> /^v\d+\.\d+\.\d\+/.match 'v0.2.1'
=> nil
irb(main):002:0> /^v\d+\.\d+\.\d+/.match 'v0.2.1'
=> #<MatchData "v0.2.1">
```