### PR TITLE
Fix gem publishing from builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,12 +8,12 @@ rubygems-login: &rubygems-login
       echo ":rubygems_api_key: $RUBYGEMS_API_KEY" >  ~/.gem/credentials
       chmod 0600 ~/.gem/credentials
 
-install-git: &install-git
-  run: apk add --no-cache --no-progress git
+install-packages: &install-packages
+  run: apk add --no-cache --no-progress git openssh
 
 defaults: &defaults
   steps:
-    - *install-git
+    - *install-packages
     - checkout
     - run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
     - run: bundle exec rake test
@@ -28,7 +28,7 @@ jobs:
   deploy-gem:
     <<: *default-deploys
     steps:
-      - *install-git
+      - *install-packages
       - checkout
       - *rubygems-login
       - run:
@@ -42,7 +42,7 @@ jobs:
   deploy-pre-release-gem:
     <<: *default-deploys
     steps:
-      - *install-git
+      - *install-packages
       - checkout
       - *rubygems-login
       - run:


### PR DESCRIPTION
Install openssh in circleci builds

Issue:

```
Either git or ssh (required by git to clone through SSH) is not installed in the image. Falling back to CircleCI's native git client but the behavior may be different from official git. If this is an issue, please use an image that has official git and ssh installed.
object not found
Counting objects: 324, done.
Compressing objects: 100% (42/42), done.
Total 324 (delta 17), reused 43 (delta 9), pack-reused 262
```

Example: https://circleci.com/gh/FundingCircle/sshkit-backends-netssh_global/85

